### PR TITLE
fix: league page shows team performance in descending order (showing …

### DIFF
--- a/lib/league/league_game/bloc/league_game_bloc.dart
+++ b/lib/league/league_game/bloc/league_game_bloc.dart
@@ -113,13 +113,15 @@ class LeagueGameBloc extends Bloc<LeagueGameEvent, LeagueGameState> {
     rosters.forEach((address, roster) {
       final teamPerformance = _calculateTeamPerformanceUseCase
           .calculateTeamPerformance(roster, athletes);
-      userTeams.add(
-        UserTeam(
-          address: address,
-          roster: roster,
-          teamPerformance: teamPerformance,
-        ),
-      );
+      userTeams
+        ..add(
+          UserTeam(
+            address: address,
+            roster: roster,
+            teamPerformance: teamPerformance,
+          ),
+        )
+        ..sort((b, a) => a.teamPerformance.compareTo(b.teamPerformance));
     });
     emit(
       state.copyWith(


### PR DESCRIPTION
…the top scoring team to the lowest scoring team)

# Description
Sort the teams on the league page by descending order. It shows the user Teams from the highest scoring team to the lowest scoring team

Fixes Jira Ticket # 

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Is this a UI Change? If so please include screenshot of before and after states below
![image](https://user-images.githubusercontent.com/89420193/230296094-98f36730-b235-41ef-85d3-052ed345c5e6.png)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have assigned 2 reviewers to check my work
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
