### PR TITLE
fix: user is now able to remove liquidity at 100%

### DIFF
--- a/lib/service/controller/pool/pool_repository.dart
+++ b/lib/service/controller/pool/pool_repository.dart
@@ -1,4 +1,5 @@
 import 'package:ax_dapp/service/controller/controller.dart';
+import 'package:ax_dapp/util/truncate_double.dart';
 import 'package:ax_dapp/util/user_input_norm.dart';
 import 'package:ethereum_api/apt_factory_api.dart';
 import 'package:ethereum_api/apt_router_api.dart';
@@ -117,7 +118,9 @@ class PoolRepository {
     final lpToken =
         ERC20(address: lpTokenEthAddress, client: controller.client.value);
     final tokenBalance = await getTokenBalanceHandler(lpTokenPairAddress);
-    final lpTokenBalance = normalizeInput(tokenBalance ?? 0);
+    final truncatedTokenBalance =
+        truncateToDecimalPlaces(value: tokenBalance ?? 0, fractionalDigits: 6);
+    final lpTokenBalance = normalizeInput(truncatedTokenBalance);
     final approveAmount =
         (lpTokenBalance * BigInt.from(removePercentage)) ~/ BigInt.from(100);
     try {
@@ -136,7 +139,9 @@ class PoolRepository {
     Future<double?> Function(String address) getTokenBalanceHandler,
   ) async {
     final tokenBalance = await getTokenBalanceHandler(lpTokenPairAddress);
-    final lpTokenBalance = normalizeInput(tokenBalance ?? 0);
+    final truncatedTokenBalance =
+        truncateToDecimalPlaces(value: tokenBalance ?? 0, fractionalDigits: 6);
+    final lpTokenBalance = normalizeInput(truncatedTokenBalance);
     final liquidity =
         (lpTokenBalance * BigInt.from(removePercentage)) ~/ BigInt.from(100);
     final amountAMin = BigInt.zero;

--- a/lib/util/truncate_double.dart
+++ b/lib/util/truncate_double.dart
@@ -1,0 +1,11 @@
+import 'dart:math';
+
+/// [truncateToDecimalPlaces] will truncate the [value] and not round it
+/// This is to circumnavigate [double.toStringAsFixed] because this will round the decimal place
+double truncateToDecimalPlaces({
+  required double value,
+  required int fractionalDigits,
+}) {
+  return (value * pow(10, fractionalDigits)).truncate() /
+      pow(10, fractionalDigits);
+}

--- a/test/truncate_double_test.dart
+++ b/test/truncate_double_test.dart
@@ -1,0 +1,46 @@
+import 'package:ax_dapp/util/truncate_double.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Truncate to decimal places', () {
+    test('2 decimal places', () {
+      const value = 3.14159265359;
+      const fractionalDigits = 2;
+      final result = truncateToDecimalPlaces(
+        value: value,
+        fractionalDigits: fractionalDigits,
+      );
+      expect(result, equals(3.14));
+    });
+
+    test('4 decimal places', () {
+      const value = 123.456789;
+      const fractionalDigits = 4;
+      final result = truncateToDecimalPlaces(
+        value: value,
+        fractionalDigits: fractionalDigits,
+      );
+      expect(result, equals(123.4567));
+    });
+
+    test('6 decimal places', () {
+      const value = 0.987654321;
+      const fractionalDigits = 6;
+      final result = truncateToDecimalPlaces(
+        value: value,
+        fractionalDigits: fractionalDigits,
+      );
+      expect(result, equals(0.987654));
+    });
+
+    test('No truncation needed', () {
+      const value = 10.0;
+      const fractionalDigits = 3;
+      final result = truncateToDecimalPlaces(
+        value: value,
+        fractionalDigits: fractionalDigits,
+      );
+      expect(result, equals(10.0));
+    });
+  });
+}


### PR DESCRIPTION
# Description
This bug fix addresses the 100% liquidity removal rounding bug for my liquidity feature

- truncates the value to 6 decimal places while leaving it _**NOT**_ rounded
- this means that the approval amount will not exceed the balance
- wrote tests to ensure this behaves as intended

Fixes Jira Ticket # 

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Is this a UI Change? If so please include screenshot of before and after states below

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have assigned 2 reviewers to check my work
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
